### PR TITLE
Optimize terrain customization jobs

### DIFF
--- a/Assets/Scripts/Terrain Customization/ApplyLayersJob.cs
+++ b/Assets/Scripts/Terrain Customization/ApplyLayersJob.cs
@@ -22,18 +22,13 @@ public unsafe struct ApplyLayersJob : IJob
         var entitiesWriter = entities.AsParallelWriter();
         void* entitiesPtr = UnsafeUtility.AddressOf(ref entitiesWriter);
 
-        // Placeholder for input heightmap
-        var inputHeightmap = new NativeArray<float>(heightmap.Length, Allocator.Temp);
-
         for (int i = 0; i < layers.Length; i++)
         {
             var layer = layers[i];
             if (layer.enabled)
             {
-                layer.Apply(seed, density, voxelTypes, chunkSize, in offset, scale, entitiesPtr, heightmap, inputHeightmap);
+                layer.Apply(seed, density, voxelTypes, chunkSize, in offset, scale, entitiesPtr, heightmap);
             }
         }
-        
-        inputHeightmap.Dispose();
     }
 }

--- a/Assets/Scripts/Terrain Customization/GenerateHeightmapJob.cs
+++ b/Assets/Scripts/Terrain Customization/GenerateHeightmapJob.cs
@@ -14,18 +14,13 @@ public struct GenerateHeightmapJob : IJob
 
     public void Execute()
     {
-        // Placeholder for input heightmap
-        var inputHeightmap = new NativeArray<float>(heightmap.heights.Length, Allocator.Temp);
-
         for (int i = 0; i < layers.Length; i++)
         {
             var layer = layers[i];
             if (layer.enabled)
             {
-                layer.Apply(seed, ref heightmap, in offset, scale, inputHeightmap);
+                layer.Apply(seed, ref heightmap, in offset, scale);
             }
         }
-        
-        inputHeightmap.Dispose();
     }
 }

--- a/Assets/Scripts/Terrain Customization/Terrain Operation Layers/ApplyDefaultTextureTerrainLayer.cs
+++ b/Assets/Scripts/Terrain Customization/Terrain Operation Layers/ApplyDefaultTextureTerrainLayer.cs
@@ -10,7 +10,7 @@ using UnityEngine;
 public unsafe struct ApplyDefaultTextureTerrainLayer : ITerrainLayer
 {
     [BurstCompile]
-    public static void Apply(ref TerrainLayer layer, int seed, float* density, byte* voxelTypes, int densityLength, int chunkSize, in float3 offset, float scale, void* entities, float* heightmap, int heightmapLength, float* inputHeightmap, int inputHeightmapLength)
+    public static void Apply(ref TerrainLayer layer, int seed, float* density, byte* voxelTypes, int densityLength, int chunkSize, in float3 offset, float scale, void* entities, float* heightmap, int heightmapLength)
     {
         if (!layer.enabled) return;
 

--- a/Assets/Scripts/Terrain Customization/Terrain Operation Layers/ErosionHeightmapLayer.cs
+++ b/Assets/Scripts/Terrain Customization/Terrain Operation Layers/ErosionHeightmapLayer.cs
@@ -10,7 +10,7 @@ public unsafe struct ErosionHeightmapLayer : IHeightmapLayer
     private const float PI = 3.14159265359f;
 
     [BurstCompile]
-    public static void Apply(ref HeightmapLayer layer, int seed, ref Heightmap heightmap, in float3 offset, float scale, float* inputHeightmap, int inputHeightmapLength)
+    public static void Apply(ref HeightmapLayer layer, int seed, ref Heightmap heightmap, in float3 offset, float scale)
     {
         if (!layer.enabled) return;
 

--- a/Assets/Scripts/Terrain Customization/Terrain Operation Layers/HeightmapLayer.cs
+++ b/Assets/Scripts/Terrain Customization/Terrain Operation Layers/HeightmapLayer.cs
@@ -7,7 +7,7 @@ using Unity.Mathematics;
 [BurstCompile]
 public unsafe struct HeightmapLayer
 {
-    public delegate void ApplyDelegate(ref HeightmapLayer layer, int seed, ref Heightmap heightmap, in float3 offset, float scale, float* inputHeightmap, int inputHeightmapLength);
+    public delegate void ApplyDelegate(ref HeightmapLayer layer, int seed, ref Heightmap heightmap, in float3 offset, float scale);
 
     public FunctionPointer<ApplyDelegate> ApplyFunction;
 
@@ -16,8 +16,8 @@ public unsafe struct HeightmapLayer
 
     public fixed float properties[16];
 
-    public void Apply(int seed, ref Heightmap heightmap, in float3 offset, float scale, NativeArray<float> inputHeightmap)
+    public void Apply(int seed, ref Heightmap heightmap, in float3 offset, float scale)
     {
-        ApplyFunction.Invoke(ref this, seed, ref heightmap, in offset, scale, (float*)inputHeightmap.GetUnsafeReadOnlyPtr(), inputHeightmap.Length);
+        ApplyFunction.Invoke(ref this, seed, ref heightmap, in offset, scale);
     }
 }

--- a/Assets/Scripts/Terrain Customization/Terrain Operation Layers/HeightmapToVoxelLayer.cs
+++ b/Assets/Scripts/Terrain Customization/Terrain Operation Layers/HeightmapToVoxelLayer.cs
@@ -7,7 +7,7 @@ using Unity.Mathematics;
 public unsafe struct HeightmapToVoxelLayer : ITerrainLayer
 {
     [BurstCompile]
-    public static void Apply(ref TerrainLayer layer, int seed, float* density, byte* voxelTypes, int densityLength, int chunkSize, in float3 offset, float scale, void* entities, float* heightmap, int heightmapLength, float* inputHeightmap, int inputHeightmapLength)
+    public static void Apply(ref TerrainLayer layer, int seed, float* density, byte* voxelTypes, int densityLength, int chunkSize, in float3 offset, float scale, void* entities, float* heightmap, int heightmapLength)
     {
         if (!layer.enabled) return;
 

--- a/Assets/Scripts/Terrain Customization/Terrain Operation Layers/PerlinNoiseHeightmapLayer.cs
+++ b/Assets/Scripts/Terrain Customization/Terrain Operation Layers/PerlinNoiseHeightmapLayer.cs
@@ -8,7 +8,7 @@ using Unity.Mathematics;
 public unsafe struct PerlinNoiseHeightmapLayer : IHeightmapLayer
 {
     [BurstCompile]
-    public static void Apply(ref HeightmapLayer layer, int seed, ref Heightmap heightmap, in float3 offset, float scale, float* inputHeightmap, int inputHeightmapLength)
+    public static void Apply(ref HeightmapLayer layer, int seed, ref Heightmap heightmap, in float3 offset, float scale)
     {
         if (!layer.enabled) return;
 

--- a/Assets/Scripts/Terrain Customization/Terrain Operation Layers/TerrainLayer.cs
+++ b/Assets/Scripts/Terrain Customization/Terrain Operation Layers/TerrainLayer.cs
@@ -7,7 +7,7 @@ using Unity.Mathematics;
 [BurstCompile]
 public unsafe struct TerrainLayer
 {
-    public delegate void ApplyDelegate(ref TerrainLayer layer, int seed, float* density, byte* voxelTypes, int densityLength, int chunkSize, in float3 offset, float scale, void* entities, float* heightmap, int heightmapLength, float* inputHeightmap, int inputHeightmapLength);
+    public delegate void ApplyDelegate(ref TerrainLayer layer, int seed, float* density, byte* voxelTypes, int densityLength, int chunkSize, in float3 offset, float scale, void* entities, float* heightmap, int heightmapLength);
 
     public FunctionPointer<ApplyDelegate> ApplyFunction;
 
@@ -16,8 +16,8 @@ public unsafe struct TerrainLayer
 
     public fixed float properties[16];
 
-    public void Apply(int seed, NativeArray<float> density, NativeArray<byte> voxelTypes, int chunkSize, in float3 offset, float scale, void* entities, NativeArray<float> heightmap, NativeArray<float> inputHeightmap)
+    public void Apply(int seed, NativeArray<float> density, NativeArray<byte> voxelTypes, int chunkSize, in float3 offset, float scale, void* entities, NativeArray<float> heightmap)
     {
-        ApplyFunction.Invoke(ref this, seed, (float*)density.GetUnsafePtr(), (byte*)voxelTypes.GetUnsafePtr(), density.Length, chunkSize, in offset, scale, entities, (float*)heightmap.GetUnsafeReadOnlyPtr(), heightmap.Length, (float*)inputHeightmap.GetUnsafeReadOnlyPtr(), inputHeightmap.Length);
+        ApplyFunction.Invoke(ref this, seed, (float*)density.GetUnsafePtr(), (byte*)voxelTypes.GetUnsafePtr(), density.Length, chunkSize, in offset, scale, entities, (float*)heightmap.GetUnsafeReadOnlyPtr(), heightmap.Length);
     }
 }


### PR DESCRIPTION
## Summary
- eliminate temporary heightmap buffers in terrain customization jobs
- streamline layer delegates by removing unused inputHeightmap argument
- simplify layer implementations to reduce per-chunk allocations

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68ab3d6e269c83209413140ade23c966